### PR TITLE
adds clippy suggestions and anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,14 +502,16 @@ dependencies = [
 
 [[package]]
 name = "moonbird"
-version = "0.1.2"
+version = "0.1.0"
 dependencies = [
  "again",
+ "anyhow",
  "bytes",
  "clap",
  "futures",
  "reqwest",
  "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moonbird"
-version = "0.1.2"
+version = "0.1.0"
 authors = ["Nicolás Siplis"]
 edition = "2021"
 
@@ -13,4 +13,6 @@ futures = "*"
 clap = { version = "*", features = ["derive"] }
 reqwest = { version = "*", features = ["json"] }
 serde = { version = "*", features = ["derive"] }
+serde_json = "*"
 tokio = { version = "*", features = ["full"] }
+anyhow = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,268 +1,267 @@
-extern crate core;
-
-use std::env::temp_dir;
-use std::fs::OpenOptions;
-use std::io::Write;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Duration;
+use serde::{Deserialize, Serialize};
 use again::RetryPolicy;
 use clap::Parser;
-use futures::{StreamExt};
-use futures::stream::iter;
-use reqwest::Client;
+use futures::{stream::iter, StreamExt};
+use anyhow::{Context, Result, anyhow};
+use std::{
+  fs::OpenOptions,
+  io::Write,
+  sync::atomic::{AtomicUsize, Ordering},
+  time::Duration
+};
 use reqwest::header::AUTHORIZATION;
-use serde::{Deserialize, Serialize};
-use tokio::fs::{File, remove_file, write};
-use tokio::io::AsyncReadExt;
+use tokio::{
+  fs::{File, remove_file, write, read},
+};
 
 #[tokio::main]
-async fn main() {
-    let args = Args::parse();
+async fn main() -> Result<()> {
+  let args = Args::parse();
 
-    let id = &args.space;
+  if args.file.is_none() {
+    println!("No name specified, will create audio file with default space name");
+  }
 
-    let bearer = &format!("Bearer {}", args.bearer);
+  Guest::new(&args.bearer).await?
+    .space(&args.space).await?
+    .download(args.file, args.concurrency).await?;
 
-    let name = &args.file.or_else(|| {
-        println!("No name specified, will create audio file with default space name");
-        None
-    });
-
-    let concurrency = args.concurrency;
-
-    download(id, name, bearer, concurrency).await;
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct Guest {
-    guest_token: String,
-}
-
-impl Guest {
-    async fn new(bearer: &String) -> Guest {
-        let client = reqwest::Client::new();
-        let response = client
-            .post("https://api.twitter.com/1.1/guest/activate.json")
-            .header(AUTHORIZATION, bearer)
-            .send()
-            .await
-            .unwrap()
-            .json::<Guest>()
-            .await
-            .unwrap();
-        println!("Guest:\n{:?}", response);
-        response
-    }
-}
-
-impl Space {
-    async fn new(guest: &Guest, bearer: &String, id: &String) -> Space {
-        let id = id
-            .split("?")
-            .collect::<Vec<&str>>()[0]
-            .replace("https://", "")
-            .replace("twitter.com/i/spaces/", "")
-            .replace("/", "");
-
-        let address = format!(
-            "https://twitter.com/i/api/graphql/Uv5R_-Chxbn1FEkyUkSW2w/AudioSpaceById?variables=%7B%22id%22%3A%22{}%22%2C%22isMetatagsQuery%22%3Afalse%2C%22withBirdwatchPivots%22%3Afalse%2C%22withDownvotePerspective%22%3Afalse%2C%22withReactionsMetadata%22%3Afalse%2C%22withReactionsPerspective%22%3Afalse%2C%22withReplays%22%3Afalse%2C%22withScheduledSpaces%22%3Afalse%2C%22withSuperFollowsTweetFields%22%3Afalse%2C%22withSuperFollowsUserFields%22%3Afalse%7D",
-            id
-        );
-
-        println!("{}", address);
-
-        let client = reqwest::Client::new();
-        let res = client
-            .get(address.to_string())
-            .header(AUTHORIZATION, bearer)
-            .header("X-Guest-Token", &guest.guest_token)
-            .send()
-            .await
-            .unwrap();
-
-        res.json::<Space>().await.unwrap()
-    }
-
-    fn admins(&self) -> String {
-        self.data.audio_space.participants.admins
-            .iter()
-            .map(|admin| format!("{}{}", admin.display_name, ","))
-            .collect()
-    }
-
-    fn name(&self) -> &String {
-        &self.data.audio_space.metadata.title
-    }
-
-    async fn stream(&self, guest: &Guest, bearer: &String) -> Stream {
-        let address = format!(
-            "https://twitter.com/i/api/1.1/live_video_stream/status/{}",
-            &self.data.audio_space.metadata.media_key
-        );
-        let client = reqwest::Client::new();
-        client
-            .get(address)
-            .header(AUTHORIZATION, bearer)
-            .header("X-Guest-Token", &guest.guest_token)
-            .send()
-            .await
-            .unwrap()
-            .json()
-            .await
-            .unwrap()
-    }
-}
-
-async fn download(id: &String, name: &Option<String>, bearer: &String, concurrency: usize) {
-    let guest = &Guest::new(bearer).await;
-    let space = Space::new(guest, bearer, id).await;
-    let stream = space.stream(&guest, bearer).await;
-
-    let location = stream.source.location.as_str();
-    let base_uri: Vec<String> = location.split("playlist").map(str::to_string).collect();
-    let space_name: &String = &space
-        .name()
-        .chars()
-        .filter(|c| c.is_alphanumeric() || c.is_whitespace() || "—-_".contains(&c.to_string()))
-        .collect();
-
-    println!("Admins: {}\nTitle: {}\nLocation: {}", space.admins(), space_name, location);
-
-    let chunks: Vec<String> = stream
-        .chunks(guest, bearer)
-        .await
-        .split("\n")
-        .filter(|c| !c.contains("#"))
-        .map(str::to_string)
-        .collect();
-    let size = chunks.len();
-
-
-    let count = AtomicUsize::new(0);
-    let client = reqwest::Client::new();
-    let mut index = 1;
-
-    let chunks = chunks
-        .iter()
-        .map(|chunk| format!("{}{}", base_uri[0], chunk))
-        .map(|chunk_url| {
-            let f = fetch_url(&space_name, size, index, chunk_url, &count, &client);
-            index += 1;
-            f
-        });
-
-    iter(chunks).buffer_unordered(concurrency).collect::<()>().await;
-
-    let name = name.clone().unwrap_or(space_name.clone()) + ".aac";
-
-    remove_file(&name).await.unwrap_or_else(|_| ());
-    File::create(&name).await.unwrap();
-
-    let mut space_file = OpenOptions::new().append(true).open(&name).unwrap();
-
-    for i in 1..index {
-        let bytes = &mut vec![];
-        let path = format!("{}/{}_{}", temp_dir().to_str().unwrap(), &space_name, i);
-        File::open(&path).await.unwrap().read_to_end(bytes).await.unwrap();
-        space_file.write(bytes.as_slice()).unwrap();
-        remove_file(&path).await.unwrap();
-    }
-}
-
-async fn fetch_url(space_name: &String, size: usize, index: i32, url: String, count: &AtomicUsize, client: &Client) {
-    let policy = RetryPolicy::exponential(Duration::from_secs(1))
-        .with_max_retries(5)
-        .with_jitter(true);
-
-    let response = policy.retry(|| client.get(&url).send())
-        .await
-        .unwrap_or_else(|e| panic!("Error while downloading chunk #{}:\n{}", index, e));
-
-    let bytes = response.bytes().await.unwrap();
-
-    write(format!("{}/{}_{}", temp_dir().to_str().unwrap(), space_name, index), bytes.to_vec().as_slice()).await.unwrap();
-    count.fetch_add(1, Ordering::SeqCst);
-    println!("Chunk #{} Downloaded - {} Remaining", index, size - count.load(Ordering::SeqCst));
-}
-
-
-impl Stream {
-    async fn chunks(&self, guest: &Guest, bearer: &String) -> String {
-        reqwest::Client::new()
-            .get(&self.source.location)
-            .header(AUTHORIZATION, bearer)
-            .header("X-Guest-Token", &guest.guest_token)
-            .send()
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap()
-    }
+  println!("\nDone");
+  Ok(())
 }
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
-    /// ID of the space to download
-    #[clap(short, long)]
-    space: String,
+  /// ID of the space to download
+  #[clap(short, long)]
+  space: String,
 
-    /// Name for the generated audio file
-    #[clap(short, long)]
-    file: Option<String>,
+  /// Name for the generated audio file
+  #[clap(short, long)]
+  file: Option<String>,
 
-    /// Maximum allowed amount of concurrent fragment requests while downloading space
-    #[clap(short, long, default_value_t = 50)]
-    concurrency: usize,
+  /// Maximum allowed amount of concurrent fragment requests while downloading space
+  #[clap(short, long, default_value_t = 50)]
+  concurrency: usize,
 
-    /// Authentication token to get required metadata
-    #[clap(
-    short, long,
-    default_value = "AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs=1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA"
-    )]
-    bearer: String,
+  /// Authentication token to get required metadata
+  #[clap(
+  short, long,
+  default_value = "AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs=1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA"
+  )]
+  bearer: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct Space {
-    data: Data,
+struct Guest {
+  bearer_token: String,
+  guest_token: String,
+}
+
+impl Guest {
+  async fn new(bearer: &str) -> Result<Guest> {
+    let client = reqwest::Client::new();
+    let bearer_token = format!("Bearer {}", bearer);
+
+    let guest_token = client
+      .post("https://api.twitter.com/1.1/guest/activate.json")
+      .header(AUTHORIZATION, &bearer_token)
+      .send().await
+      .with_context(|| "Error fetching guest token".to_string() )?
+      .json::<serde_json::Value>().await
+      .with_context(|| "Guest token responsa was not json".to_string())?
+      .get("guest_token")
+      .and_then(|f| f.as_str())
+      .ok_or_else(|| anyhow!("No guest_token attribute found"))?
+      .to_string();
+
+    println!("Guest:\n{:?}", guest_token);
+    Ok(Self { bearer_token, guest_token })
+  }
+
+  async fn space<'a>(&'a self, id: &str) -> Result<Space<'a>> {
+    Space::new(self, id).await
+  }
+
+  async fn get(&self, url: &str) -> Result<reqwest::Response> {
+    Ok(reqwest::Client::new()
+      .get(url)
+      .header(AUTHORIZATION, &self.bearer_token)
+      .header("X-Guest-Token", &self.guest_token)
+      .send().await?)
+  }
+}
+
+struct Space<'a> {
+  guest: &'a Guest,
+  attrs: SpaceAttrs,
+  name: String,
+  admins: String,
+}
+
+impl<'a> Space<'a> {
+  async fn new(guest: &'a Guest, id: &str) -> Result<Space<'a>> {
+    let id = id
+      .split('?')
+      .collect::<Vec<&str>>()[0]
+      .replace("https://", "")
+      .replace("twitter.com/i/spaces/", "")
+      .replace("/", "");
+
+    let address = format!(
+      "https://twitter.com/i/api/graphql/Uv5R_-Chxbn1FEkyUkSW2w/AudioSpaceById?variables=%7B%22id%22%3A%22{}%22%2C%22isMetatagsQuery%22%3Afalse%2C%22withBirdwatchPivots%22%3Afalse%2C%22withDownvotePerspective%22%3Afalse%2C%22withReactionsMetadata%22%3Afalse%2C%22withReactionsPerspective%22%3Afalse%2C%22withReplays%22%3Afalse%2C%22withScheduledSpaces%22%3Afalse%2C%22withSuperFollowsTweetFields%22%3Afalse%2C%22withSuperFollowsUserFields%22%3Afalse%7D",
+      id
+    );
+
+    println!("{}", address);
+
+    let res = guest.get(&address).await?;
+
+    let attrs = res.json::<SpaceAttrs>().await?;
+
+    let name = attrs.data.audio_space.metadata.title
+      .chars()
+      .filter(|c| c.is_alphanumeric() || c.is_whitespace() || "—-_".contains(&c.to_string()))
+      .collect();
+
+    let admins = attrs.data.audio_space.participants.admins
+      .iter()
+      .map(|admin| format!("{}{}", admin.display_name, ","))
+      .collect();
+
+    Ok(Self{ guest, attrs, name, admins })
+  }
+
+  async fn download(&self, name: Option<String>, concurrency: usize) -> Result<()> {
+    let stream = self.stream().await?;
+
+    println!("Admins: {}\nTitle: {}\nLocation: {}", self.admins, self.name, stream.location());
+    
+    let filename = format!("{}.aac", name.as_ref().unwrap_or(&self.name));
+    let _ = remove_file(&filename).await;
+    File::create(&filename).await?;
+
+    let mut space_file = OpenOptions::new().append(true).open(&filename)?;
+
+    for path in stream.fetch_chunks(concurrency).await? {
+      space_file.write_all(&read(&path).await?)?;
+      remove_file(&path).await?;
+    }
+
+    Ok(())
+  }
+
+  async fn stream(&'a self) -> Result<Stream<'a>> {
+    Stream::new(self).await
+  }
+}
+
+struct Stream<'a> {
+  space: &'a Space<'a>,
+  attrs: StreamAttrs,
+}
+
+impl<'a> Stream<'a> {
+  pub async fn new(space: &'a Space<'a>) -> Result<Stream<'a>> {
+    let address = format!(
+      "https://twitter.com/i/api/1.1/live_video_stream/status/{}",
+      &space.attrs.data.audio_space.metadata.media_key
+    );
+    let attrs = space.guest.get(&address).await?.json::<StreamAttrs>().await?;
+
+    Ok(Self{ attrs, space })
+  }
+
+  pub async fn fetch_chunks(&self, concurrency: usize) -> Result<Vec<String>> {
+    let base_uri = self.location().split("playlist").next()
+      .ok_or_else(|| anyhow!("Could not parse base_uri from location"))?;
+    let count = AtomicUsize::new(0);
+
+    let chunks = self.chunks().await?;
+    let size = chunks.len();
+
+    let futures = chunks.into_iter().enumerate().map(|(index, chunk_name)| {
+      let client = reqwest::Client::new();
+      let url = format!("{}{}", base_uri, chunk_name);
+      let filename = format!("{}_{}", self.space.name, index);
+      let policy = RetryPolicy::exponential(Duration::from_secs(1))
+        .with_max_retries(5)
+        .with_jitter(true);
+      let count_ref = &count;
+
+      async move {
+        let bytes = policy.retry(|| client.get(&url).send() ).await
+          .map_err(|e| anyhow!("Error while downloading chunk #{}:\n{}", index, e))?
+          .bytes().await?;
+
+        write(&filename, bytes).await?;
+        count_ref.fetch_add(1, Ordering::SeqCst);
+
+        print!("\rChunk {:>8}/{:<8}", index, size);
+
+        Ok(filename)
+      }
+    });
+
+    iter(futures).buffer_unordered(concurrency)
+      .collect::<Vec<Result<String>>>().await
+      .into_iter().collect()
+  }
+
+  async fn chunks(&self) -> Result<Vec<String>> {
+    Ok(self.space.guest.get(self.location()).await?
+      .text().await?
+      .split('\n')
+      .filter(|c| !c.contains('#'))
+      .map(str::to_string)
+      .collect())
+  }
+
+  pub fn location(&'a self) -> &'a str {
+    &self.attrs.source.location
+  }
+}
+
+#[derive(Debug, Deserialize)]
+struct SpaceAttrs {
+  data: Data,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Data {
-    #[serde(rename(serialize = "audioSpace", deserialize = "audioSpace"))]
-    audio_space: AudioSpace,
+  #[serde(rename(serialize = "audioSpace", deserialize = "audioSpace"))]
+  audio_space: AudioSpace,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct AudioSpace {
-    metadata: Metadata,
-    participants: Participants,
+  metadata: Metadata,
+  participants: Participants,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Metadata {
-    media_key: String,
-    title: String,
+  media_key: String,
+  title: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Participants {
-    admins: Vec<Admin>,
+  admins: Vec<Admin>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Admin {
-    display_name: String,
+  display_name: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct Stream {
-    source: Source,
+struct StreamAttrs {
+  source: Source,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Source {
-    location: String,
+  location: String,
 }


### PR DESCRIPTION
Primero le corri 'clippy' porque vi que había muchos &String y eso casi siempre se puede reemplazar por &str.

Los patterns de OOP en rust no son siempre obvios, más cuando las estructuras se pueden serializar o deserializar. Apliqué un patrón que uso mucho de tener estructuras que se delegan tareas, y cada una de ellas tiene un campo especial "attrs" con una estructura dedicada específicamente a guardar atributos que se serializan/deserializan.

Esas estructuras necesitan explicitar algunos lifetimes, porque trabajan todas sobre los mismos datos y la principal (guest) le presta los datos a las otras para delegarles trabajo. Con esos lifetimes el compilador sabe que los datos van a vivir tanto como la estructura principal que es la dueña.

También puse 'anyhow' para no hacer unwraps, el error handling de rust es todavía un tema áspero. Usás anyhow cuando querés convertir errores de cualquier librería en un tipo de error global de tu aplicacion y lo vas a manejar desde un solo lugar. Y hay una librería hermana que se llama thiserror que la usarías cuando hacés una librería para definir un Enum de errores de tu aplicación que le da más granularidad a tu usuario.

Saludos!